### PR TITLE
rename image name `dnsmasq-precise` to `amplab/dnsmasq-precise`

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -5,7 +5,7 @@ BASEDIR=$(cd $(dirname $0); pwd)
 
 spark_images=( "amplab/spark:0.7.3" "amplab/spark:0.8.0" )
 shark_images=( "amplab/shark:0.7.0" "amplab/shark:0.8.0" )
-NAMESERVER_IMAGE="dnsmasq-precise"
+NAMESERVER_IMAGE="amplab/dnsmasq-precise"
 
 start_shell=0
 VOLUME_MAP=""


### PR DESCRIPTION
There is a small error in line 8 of `deploy/deploy.sh`,  the image name for `dnsmasq` is wrong, which shoud be `amplab/dnsmasq-precise` instead of `dnsmasq-precise`.
