### PR TITLE
start_nameserver.sh "nameserver up" detection fix (at least on Ubuntu Precise LTS)

### DIFF
--- a/deploy/start_nameserver.sh
+++ b/deploy/start_nameserver.sh
@@ -23,12 +23,14 @@ function start_nameserver() {
 
 function wait_for_nameserver {
     echo -n "waiting for nameserver to come up "
-    # Note: the nameserver resolves its own hostname to 127.0.0.1
-    dig nameserver @${NAMESERVER_IP} | grep ANSWER -A1 | grep 127.0.0.1 > /dev/null
+    # Note: original scripts assumed the nameserver resolves its own hostname to 127.0.0.1
+    # bmustafa (24601 on GitHub) has found this not to necessarily be the case 
+    # on Ubuntu Precise LTS...this fixes it...may break other platforms? 
+    dig nameserver @${NAMESERVER_IP} | grep ANSWER -A1 | grep ${NAMESERVER_IP} > /dev/null
     until [ "$?" -eq 0 ]; do
         echo -n "."
         sleep 1
-        dig nameserver @${NAMESERVER_IP} | grep ANSWER -A1 | grep 127.0.0.1 > /dev/null;
+        dig nameserver @${NAMESERVER_IP} | grep ANSWER -A1 | grep ${NAMESERVER_IP} > /dev/null;
     done
     echo ""
 }


### PR DESCRIPTION
Nameserver would come up but script's detection relied on it a mechanism to detect which wasn't reliable on Ubuntu Precise LTS. This might break other platforms, I don't know. This fix made it work in my environment (vanilla Ubuntu Precise LTS + latest docker on said Ubuntu via vagrant on Mac OS).    

 # Note: original scripts assumed the nameserver resolves its own hostname to 127.0.0.1
    # bmustafa (24601 on GitHub) has found this not to necessarily be the case 
    # on Ubuntu Precise LTS...this fixes it...may break other platforms? 

see comments.
