### PR TITLE
Allow dnsmasq to be run as root

### DIFF
--- a/build/tag_all.sh
+++ b/build/tag_all.sh
@@ -12,6 +12,6 @@ IMAGE_PREFIX="amplab/"
 # NOTE: the order matters but this is the right one
 for i in ${image_list[@]}; do
 	image=$(echo $i | awk -F ":" '{print $1}')
-        echo docker tag ${IMAGE_PREFIX}${i} ${IMAGE_PREFIX}${image} latest
-	docker tag ${IMAGE_PREFIX}${i} ${IMAGE_PREFIX}${image} latest
+        echo docker tag ${IMAGE_PREFIX}${i} ${IMAGE_PREFIX}${image}:latest
+	docker tag ${IMAGE_PREFIX}${i} ${IMAGE_PREFIX}${image}:latest
 done

--- a/dnsmasq-precise/Dockerfile
+++ b/dnsmasq-precise/Dockerfile
@@ -6,7 +6,8 @@ VOLUME [ "/etc/dnsmasq.d" ]
 
 RUN apt-get install -y dnsmasq-base
 
-RUN echo "listen-address=__LOCAL_IP__" > /etc/dnsmasq.conf
+RUN echo "user=root" > /etc/dnsmasq.conf
+RUN echo "listen-address=__LOCAL_IP__" >> /etc/dnsmasq.conf
 RUN echo "resolv-file=/etc/resolv.dnsmasq.conf" >> /etc/dnsmasq.conf
 RUN echo "conf-dir=/etc/dnsmasq.d"  >> /etc/dnsmasq.conf
 RUN echo "domain=cluster.com"  >> /etc/dnsmasq.conf


### PR DESCRIPTION
Without this change, the dnsmasq command returns an error every time it is called and the nameserver never comes up. This is the error:
dnsmasq: setting capabilities failed: Operation not permitted

This link may have more information about why this change is now necessary:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=514214

Also, the syntax for docker tag has changed.
